### PR TITLE
7ページ目の追加&2ページ目の微調整&ボタン用cssテンプレートの作成

### DIFF
--- a/main.py
+++ b/main.py
@@ -23,7 +23,8 @@ def index():
 #         })
 #     return render_template("selected_Img.html", image_List=imagePaths)
 
-@app.route('/upload', methods=['GET', 'POST'])#画面2
+#画面2(画像選択、画像追加)
+@app.route('/upload', methods=['GET', 'POST'])
 def upload():
     # URLでhttp://127.0.0.1:5000/uploadを指定したときはGETリクエストとなるのでこっち
     if request.method == 'GET':
@@ -52,6 +53,11 @@ def page4():
     else:
         img_Name = "パラメーターがないよ"
     return render_template("testPage4.html", img_Name=img_Name)
+
+@app.route('/gameEnd', methods=["GET"])
+def gameEnd():
+    score_array = [7000,100,50]
+    return render_template("game-end.html", score_array=score_array)
 
 if __name__ == "__main__":
     # debugモードが不要の場合は、debug=Trueを消してください

--- a/static/css/button-design.css
+++ b/static/css/button-design.css
@@ -1,0 +1,29 @@
+/* ボタンデザイン用css（ここからコピーして使ってね） */
+/* #button（クラスなら.button） <- 「button」の部分は自分がつけたタグ（クラス）に変更*/
+/* クラスで設定したほうが複数のボタンに一気につけれるが全部同じになるので、大きさ等を変えたい場合は注意 */
+
+#button{
+    /* 基本となるcss。大きさ等のcssは入っていないので自分でつけてください */
+    /* padding系をこのままつけると逆に変になってしまうことがあると思うので各自変更してください */
+    background-color: skyblue;
+    border-radius: 10px;
+    border-color: rgb(67, 67, 67);
+    padding-left: 25px;
+    padding-right: 25px;
+    padding-top: 5px;
+    padding-bottom: 5px;
+    color: white;
+    text-align: center;
+}
+
+#button:disabled{
+    /* ボタンが不活性状態になっている時に適用されるcss。不活性状態にしないのならいらない */
+    border: 1px solid #999999;
+    background-color: #cccccc;
+    color: black;
+}
+
+#button:hover{
+    /* ボタンにカーソルが乗っかっている時に適用されるcss。 */
+    opacity: 0.6;
+}

--- a/static/css/game-end.css
+++ b/static/css/game-end.css
@@ -1,0 +1,84 @@
+h1{
+    text-align: center;
+    margin: 3% 0% 0% 0% ;
+    font-size: 300%;
+}
+
+/* スコア系 */
+#time_Attack_Result_Box{
+    display: flex;
+    justify-content: center;
+    margin: 0.5% 0% 2% 0% ;
+    color: black;
+}
+
+#time_Attack_Result{
+    padding-top: 1%;
+    padding-bottom: 3%;
+    padding-right: 25%;
+    padding-left: 25%;
+    font-size: 250%;
+    border: 2px solid black; 
+    background: rgb(212, 255, 185);
+}
+
+.score{
+    margin: 1% 0% 0% 0%;
+    padding-top:10px;
+    padding-bottom:10px;
+    padding-left: 25%;
+    border-bottom: 2px solid black; 
+}
+/* スコア系 */
+
+
+#buttons{
+    display: flex;
+    justify-content: flex-end;
+    width: 100%;
+    height: 300%;
+}
+.btn:hover{
+    opacity: 0.6;
+}
+
+
+/* リザルトボタン系 */
+#return_To_Title{
+    display: flex;
+    padding-right: 3%;
+    min-width: 15%;
+}
+
+#return_To_Title_Button{
+    width: 200%;
+    font-size: 1.2em;
+    background: skyblue;
+    border-radius: 10px;
+    border-color: rgb(67, 67, 67);
+    color: white;
+    text-align: center;
+}
+/* リザルトボタン系 */
+
+
+/* 難易度変更系 */
+#change_Of_Difficulty{
+    display: flex; 
+    padding-right: 15%;
+    padding-left: 3%;
+}
+
+#change_Of_Difficulty_Button{
+    width: 400%;
+    font-size: 1.2em;
+    background: skyblue;
+    border-radius: 10px;
+    border-color: rgb(67, 67, 67);
+    padding-left: 25px;
+    padding-right: 25px;
+    color: white;
+    text-align: center;
+}
+/* 難易度変更系 */
+

--- a/static/css/image-select.css
+++ b/static/css/image-select.css
@@ -1,3 +1,9 @@
+h2{
+    text-align: center;
+}
+
+
+/* 画像表示系 */
 #imageBoxes{
     display: flex;
     flex-wrap:wrap;
@@ -5,10 +11,10 @@
 }
 
 .imageBox{
-    width: 23%;
-    height: 25%;
+    width: 22%;
+    height: 22%;
     
-    margin: 1% 1% 1% 0.6%;
+    margin: 1% 1.5% 1% 1%;
     border:solid 3px black;
 }
 
@@ -28,41 +34,84 @@ input[type="radio"]:checked + label{
     text-align: center;
     word-break:break-word;
 }
+/* 画像表示系 */
 
+
+/* ボタン系 */
 .buttons{
     display: flex;
     justify-content: center;
+    width: 100%;
 }
+.btn:hover{
+    opacity: 0.6;
+}
+/* ボタン系 */
 
+
+/* ファイル追加系 */
 #open_file{
     display: inline-block;
-    width: 25%;
+    width: 30%;
     height: 25%;
     margin: 0% 0% 0% 0% ;
 }
 
 #add_button{
     display: inline-block;
-    margin: 0% 5% 0% 0% ;
+    margin: 0% 0% 0% 0% ;
+    background-color: skyblue;
+    border-radius: 10px;
+    border-color: rgb(67, 67, 67);
+    padding-left: 15px;
+    padding-right: 15px;
+    padding-top: 5px;
+    padding-bottom: 5px;
+    color: white;
+    text-align: center;
+}
+#add_button:disabled{
+    border: 1px solid #999999;
+    background-color: #cccccc;
+    color: black;
 }
 
 #add_image{
     display: inline-block;
-    margin: 0% 5% 0% 0% ;
+    margin: 0% 0% 0% 0% ;
+    background-color: skyblue;
+    border: 1px solid rgb(67, 67, 67);
+    color: white;
+    text-align: center;
 }
+/* ファイル追加系 */
 
+
+/* 決定ボタン系 */
 #decide_image{
     display: inline-block;
     width: 10%;
     height: 25%;
     margin: 0% 0% 0% 5% ;
+    
 }
 
 #decide_button{
     display: inline-block;
     width: 100%;
-}
-
-h2{
+    background-color: skyblue;
+    border-radius: 10px;
+    border-color: rgb(67, 67, 67);
+    padding-left: 25px;
+    padding-right: 25px;
+    padding-top: 5px;
+    padding-bottom: 5px;
+    color: white;
     text-align: center;
 }
+#decide_button:disabled{
+    border: 1px solid #999999;
+    background-color: #cccccc;
+    color: black;
+}
+/* 決定ボタン系 */

--- a/templates/game-end.html
+++ b/templates/game-end.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="../static/css/game-end.css">
+    <!-- <script src="{{url_for('static', filename='image-select.js')}}"></script> -->
+    <title>ゲームリザルト</title>
+  </head>
+  <body>
+    <main>
+        <h1>パズル完成</h1>
+        <!-- スコア結果を表示 -->
+        <form id="time_Attack_Result_Box" name="time_Attack_Result_Box">
+            <ol id="time_Attack_Result">
+                <p id="ranking_Title">スコアランキング</p>
+                <li class="score" id="firstTime">{{score_array[0]}} Pt</li>
+                <li class="score" id="secondTime">{{score_array[1]}} Pt</li>
+                <li class="score" id="thirdTime">{{score_array[2]}} Pt</li>
+            </ol>
+        </form> 
+
+        <div id="buttons" style="height:50px">
+            <!-- タイトルに戻るボタン -->
+            <form id="return_To_Title" name="return_To_Title" action="/" >
+                <button class="btn" id="return_To_Title_Button">タイトルに戻る</button>
+            </form>
+            
+            <!-- 同じ画像で難易度を変えるボタン(おそらく画像のファイル名がいるのでinput[type="hidden"]のvalueに画像のファイル名を入れたい) -->
+            <form id="change_Of_Difficulty" name="change_Of_Difficulty" action="/page4" >
+                <input type="hidden" name="img_Name" value="" >
+                <button class="btn" id="change_Of_Difficulty_Button">同じ画像で難易度を変える</button>
+            </form>
+        </div>
+        
+    </main>
+  </body>
+</html>

--- a/templates/image-select.html
+++ b/templates/image-select.html
@@ -12,14 +12,14 @@
       <h2>画像を選択</h2>
       <div class="buttons">
         <form action="{{url_for('upload')}}" method="POST" enctype="multipart/form-data" id="open_file" name="add">
-          <button id="add_button" type="submit" disabled="true">画像を追加</button>
+          <button class="btn" id="add_button" type="submit" disabled="true">画像を追加</button>
           <input id="add_image" type="file" accept=".jpeg,.jpg,.png" name="image_file" onchange="onAddButton()">
           <!-- <input id="add_image" type="submit" value="画像を追加"> -->
         </form>
         
         <form id="decide_image" name="decide" action="/page4" >
           <input type="hidden" name="img_Name" value="" >
-          <button id="decide_button" disabled="true">決定</button>
+          <button class="btn" id="decide_button" disabled="true">決　定</button>
         </form>
         
       </div>


### PR DESCRIPTION
- 7ページ目を表示するメソッドを追加
- 7ページ目のhtmlを追加&要素配置
- スコア配列を渡してもらえれば3位までのスコアを表示できるようにした
- タイトル画面に戻るボタンの実装
- 同じ画像で難易度を変更するボタンの実装（**画像のファイル名必要**）
- 7ページ目用のcssを追加
- 2ページ目のhtmlを微調整
- 2ページ目のcssを修正
- ボタン用cssをコピーできるよう個別でcssを作成